### PR TITLE
Added float to int convertor in screens calculation

### DIFF
--- a/qdrawsettings.py
+++ b/qdrawsettings.py
@@ -78,8 +78,10 @@ class QdrawSettings(QWidget):
     def center(self):
         screen = QDesktopWidget().screenGeometry()
         size = self.geometry()
-        self.move((screen.width() - size.width()) / 2,
-                  (screen.height() - size.height()) / 2)
+        self.move(
+            int((screen.width() - size.width()) / 2),
+            int((screen.height() - size.height()) / 2)
+        )
 
     def closeEvent(self, e):
         self.clear()


### PR DESCRIPTION
Hello,

### Problem:

Qdraw error after install.

The function  `move(self, int, int)` needs two int parameters but we are providing two float parameters.

To solve this I added a function to convert this float to int, so with that the qdraw can be installed without errors.

Resolves #8 