### PR TITLE
Fix deprecated QgsCoordinateReferenceSystem method warnings

### DIFF
--- a/qdraw.py
+++ b/qdraw.py
@@ -241,7 +241,7 @@ class Qdraw(object):
 
     def drawDMSPoint(self):
         point, ok = DMSDialog().getPoint()
-        self.XYcrs = QgsCoordinateReferenceSystem(4326)
+        self.XYcrs = QgsCoordinateReferenceSystem.fromEpsgId(4236)
         if ok:
             if point.x() == 0 and point.y() == 0:
                 QMessageBox.critical(
@@ -382,7 +382,7 @@ then select an entity on the map.')
         g = self.geomTransform(
             self.tool.rb.asGeometry(),
             self.iface.mapCanvas().mapSettings().destinationCrs(),
-            QgsCoordinateReferenceSystem(2154))
+            QgsCoordinateReferenceSystem.fromEpsgId(2154))
         if self.toolname == 'drawLine':
             if g.length() >= 0:
                 self.sb.showMessage(


### PR DESCRIPTION
Fixes two deprecated usages of QgsCoordinateReferenceSystem instanciation:

```
2025-12-04T14:11:08     WARNING    warning:/home/user/.local/share/QGIS/QGIS3/profiles/foo/python/plugins/qdraw/qdraw.py:385: DeprecationWarning: QgsCoordinateReferenceSystem constructor is deprecated
              QgsCoordinateReferenceSystem(2154))
             
             traceback: File "/home/user/.local/share/QGIS/QGIS3/profiles/foo/python/plugins/qdraw/drawtools.py", line 323, in canvasMoveEvent
              self.move.emit()
              File "/home/user/.local/share/QGIS/QGIS3/profiles/foo/python/plugins/qdraw/qdraw.py", line 385, in updateSB
              QgsCoordinateReferenceSystem(2154))
             
2025-12-04T14:11:30     WARNING    warning:/home/user/.local/share/QGIS/QGIS3/profiles/foo/python/plugins/qdraw/qdraw.py:244: DeprecationWarning: QgsCoordinateReferenceSystem constructor is deprecated
              self.XYcrs = QgsCoordinateReferenceSystem(4326)
             
             traceback: File "/home/user/.local/share/QGIS/QGIS3/profiles/foo/python/plugins/qdraw/qdraw.py", line 244, in drawDMSPoint
              self.XYcrs = QgsCoordinateReferenceSystem(4326)
```